### PR TITLE
Allow any version of stylelint-webpack-plugin as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
   "author": "Maxime Grébauval",
   "license": "MIT",
   "homepage": "https://github.com/Ehres/react-app-rewire-stylelint",
-  "dependencies": {
-    "webpack": "^3.6.0",
-    "stylelint-webpack-plugin": "^0.9.0",
-    "stylelint": "^8.3.1"
+  "peerDependencies": {
+    "stylelint-webpack-plugin": "*"
   }
 }


### PR DESCRIPTION
I don't see a reason why we can't allow `*` as the peer dependency version, as looking through the version history of the plugin it seems it has always been used by importing it and constructing it with `new`.

This should probably be released as a major version bump, as we no longer install `stylelint`, `stylelint-webpack-plugin` or `webpack`.